### PR TITLE
add ops role granularity

### DIFF
--- a/src/LuckyBuy.sol
+++ b/src/LuckyBuy.sol
@@ -423,11 +423,10 @@ contract LuckyBuy is
     /// @notice Sets the maximum allowed reward
     /// @param maxReward_ New maximum reward value
     /// @dev Only callable by admin role
-    function setMaxReward(
-        uint256 maxReward_
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setMaxReward(uint256 maxReward_) external onlyRole(OPS_ROLE) {
+        uint256 oldMaxReward = maxReward;
         maxReward = maxReward_;
-        emit MaxRewardUpdated(maxReward, maxReward_);
+        emit MaxRewardUpdated(oldMaxReward, maxReward_);
     }
 
     /// @notice Deposits ETH into the treasury
@@ -480,9 +479,7 @@ contract LuckyBuy is
         (success, ) = to.call{value: amount}(data);
     }
 
-    function setProtocolFee(
-        uint256 protocolFee_
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setProtocolFee(uint256 protocolFee_) external onlyRole(OPS_ROLE) {
         if (protocolFee_ > BASE_POINTS) revert InvalidProtocolFee();
         _setProtocolFee(protocolFee_);
     }

--- a/src/common/MEAccessControl.sol
+++ b/src/common/MEAccessControl.sol
@@ -11,9 +11,38 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
 contract MEAccessControl is AccessControl {
     bytes32 public constant OPS_ROLE = keccak256("OPS_ROLE");
 
+    error InvalidOwner();
+
     constructor() {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(OPS_ROLE, msg.sender);
+    }
+
+    /// @notice Transfers admin rights to a new address. Admin functions are intentionally not paused
+    /// @param newAdmin Address of the new admin
+    function transferAdmin(
+        address newAdmin
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newAdmin == address(0)) revert InvalidOwner();
+
+        // Grant new admin the default admin role
+        _grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
+        _grantRole(OPS_ROLE, newAdmin);
+
+        // Revoke old admin's roles
+        _revokeRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _revokeRole(OPS_ROLE, msg.sender);
+    }
+    /// @notice Adds a new operations user
+    /// @param user Address to grant operations role to
+    function addOpsUser(address user) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        _grantRole(OPS_ROLE, user);
+    }
+
+    /// @notice Removes an operations user
+    /// @param user Address to revoke operations role from
+    function removeOpsUser(address user) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        _revokeRole(OPS_ROLE, user);
     }
 
     /**

--- a/test/AccessControl.t.sol
+++ b/test/AccessControl.t.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import "forge-std/Test.sol";
+import "../src/LuckyBuy.sol";
+import "../src/common/MEAccessControl.sol";
+import "@openzeppelin/contracts/access/IAccessControl.sol";
+contract AccessControlTest is Test {
+    LuckyBuy public luckyBuy;
+    address public admin;
+    address public ops;
+    address public user;
+
+    event CosignerAdded(address indexed cosigner);
+    event CosignerRemoved(address indexed cosigner);
+    event MaxRewardUpdated(uint256 oldMaxReward, uint256 newMaxReward);
+    event ProtocolFeeUpdated(uint256 oldProtocolFee, uint256 newProtocolFee);
+
+    function setUp() public {
+        admin = makeAddr("admin");
+        ops = makeAddr("ops");
+        user = makeAddr("user");
+
+        vm.startPrank(admin);
+        luckyBuy = new LuckyBuy(0); // Initialize with 0 protocol fee
+        vm.stopPrank();
+    }
+
+    function test_InitialRoles() public {
+        assertTrue(luckyBuy.hasRole(luckyBuy.DEFAULT_ADMIN_ROLE(), admin));
+        assertTrue(luckyBuy.hasRole(luckyBuy.OPS_ROLE(), admin));
+        assertFalse(luckyBuy.hasRole(luckyBuy.DEFAULT_ADMIN_ROLE(), ops));
+        assertFalse(luckyBuy.hasRole(luckyBuy.OPS_ROLE(), ops));
+    }
+
+    function test_AddOpsUser() public {
+        vm.startPrank(admin);
+        luckyBuy.addOpsUser(ops);
+        vm.stopPrank();
+
+        assertTrue(luckyBuy.hasRole(luckyBuy.OPS_ROLE(), ops));
+        assertFalse(luckyBuy.hasRole(luckyBuy.DEFAULT_ADMIN_ROLE(), ops));
+    }
+
+    function test_RemoveOpsUser() public {
+        vm.startPrank(admin);
+        luckyBuy.addOpsUser(ops);
+        luckyBuy.removeOpsUser(ops);
+        vm.stopPrank();
+
+        assertFalse(luckyBuy.hasRole(luckyBuy.OPS_ROLE(), ops));
+    }
+
+    function test_TransferAdmin() public {
+        address newAdmin = makeAddr("newAdmin");
+
+        vm.startPrank(admin);
+        luckyBuy.transferAdmin(newAdmin);
+        vm.stopPrank();
+
+        assertTrue(luckyBuy.hasRole(luckyBuy.DEFAULT_ADMIN_ROLE(), newAdmin));
+        assertTrue(luckyBuy.hasRole(luckyBuy.OPS_ROLE(), newAdmin));
+        assertFalse(luckyBuy.hasRole(luckyBuy.DEFAULT_ADMIN_ROLE(), admin));
+        assertFalse(luckyBuy.hasRole(luckyBuy.OPS_ROLE(), admin));
+    }
+
+    function test_RevertWhen_NonAdminAddsOpsUser() public {
+        vm.startPrank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                user,
+                luckyBuy.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        luckyBuy.addOpsUser(ops);
+        vm.stopPrank();
+    }
+
+    function test_RevertWhen_NonAdminRemovesOpsUser() public {
+        vm.startPrank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                user,
+                luckyBuy.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        luckyBuy.removeOpsUser(ops);
+        vm.stopPrank();
+    }
+
+    function test_RevertWhen_NonAdminTransfersAdmin() public {
+        vm.startPrank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                user,
+                luckyBuy.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        luckyBuy.transferAdmin(ops);
+        vm.stopPrank();
+    }
+
+    function test_AdminCanAddCosigner() public {
+        vm.startPrank(admin);
+        vm.expectEmit(true, false, false, false);
+        emit CosignerAdded(ops);
+        luckyBuy.addCosigner(ops);
+        vm.stopPrank();
+
+        assertTrue(luckyBuy.isCosigner(ops));
+    }
+
+    function test_AdminCanRemoveCosigner() public {
+        vm.startPrank(admin);
+        luckyBuy.addCosigner(ops);
+        vm.expectEmit(true, false, false, false);
+        emit CosignerRemoved(ops);
+        luckyBuy.removeCosigner(ops);
+        vm.stopPrank();
+
+        assertFalse(luckyBuy.isCosigner(ops));
+    }
+
+    function test_OpsCanSetMaxReward() public {
+        vm.startPrank(admin);
+        luckyBuy.addOpsUser(ops);
+        vm.stopPrank();
+
+        vm.startPrank(ops);
+        uint256 newMaxReward = 50 ether;
+        vm.expectEmit(false, false, false, true);
+        emit MaxRewardUpdated(30 ether, newMaxReward);
+        luckyBuy.setMaxReward(newMaxReward);
+        vm.stopPrank();
+
+        assertEq(luckyBuy.maxReward(), newMaxReward);
+    }
+
+    function test_OpsCanSetProtocolFee() public {
+        vm.startPrank(admin);
+        luckyBuy.addOpsUser(ops);
+        vm.stopPrank();
+
+        vm.startPrank(ops);
+        uint256 newFee = 500; // 5%
+        vm.expectEmit(false, false, false, true);
+        emit ProtocolFeeUpdated(0, newFee);
+        luckyBuy.setProtocolFee(newFee);
+        vm.stopPrank();
+
+        assertEq(luckyBuy.protocolFee(), newFee);
+    }
+
+    function test_RevertWhen_NonOpsSetMaxReward() public {
+        vm.startPrank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                user,
+                luckyBuy.OPS_ROLE()
+            )
+        );
+        luckyBuy.setMaxReward(50 ether);
+        vm.stopPrank();
+    }
+
+    function test_RevertWhen_NonOpsSetProtocolFee() public {
+        vm.startPrank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                user,
+                luckyBuy.OPS_ROLE()
+            )
+        );
+        luckyBuy.setProtocolFee(500);
+        vm.stopPrank();
+    }
+
+    function test_RevertWhen_ProtocolFeeExceedsBasePoints() public {
+        vm.startPrank(admin);
+        luckyBuy.addOpsUser(ops);
+        vm.stopPrank();
+
+        vm.startPrank(ops);
+        vm.expectRevert(LuckyBuy.InvalidProtocolFee.selector);
+        luckyBuy.setProtocolFee(10001); // Base points is 10000
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
Adds some granularity to the ops role.

Fixes event emission on `setMaxReward`