### PR TITLE
give cosigner expire permission

### DIFF
--- a/src/LuckyBuy.sol
+++ b/src/LuckyBuy.sol
@@ -106,9 +106,11 @@ contract LuckyBuy is
     error CommitNotExpired();
     error TransferFailed();
 
-    modifier onlyCommitOwner(uint256 commitId_) {
-        if (luckyBuys[commitId_].receiver != msg.sender)
-            revert InvalidCommitOwner();
+    modifier onlyCommitOwnerOrCosigner(uint256 commitId_) {
+        if (
+            luckyBuys[commitId_].receiver != msg.sender &&
+            luckyBuys[commitId_].cosigner != msg.sender
+        ) revert InvalidCommitOwner();
         _;
     }
 
@@ -436,7 +438,7 @@ contract LuckyBuy is
     /// @dev Emits a CommitExpired event
     function expire(
         uint256 commitId_
-    ) external onlyCommitOwner(commitId_) nonReentrant {
+    ) external onlyCommitOwnerOrCosigner(commitId_) nonReentrant {
         if (commitId_ >= luckyBuys.length) revert InvalidCommitId();
         if (isFulfilled[commitId_]) revert AlreadyFulfilled();
         if (isExpired[commitId_]) revert CommitIsExpired();

--- a/test/LuckyBuy.t.sol
+++ b/test/LuckyBuy.t.sol
@@ -1015,6 +1015,44 @@ contract TestLuckyBuyCommit is Test {
         luckyBuy.expire(0);
     }
 
+    function testExpireCommitCosigner() public {
+        vm.startPrank(admin);
+        luckyBuy.setCommitExpireTime(1 days);
+
+        vm.expectRevert(LuckyBuy.InvalidCommitExpireTime.selector);
+        luckyBuy.setCommitExpireTime(0);
+
+        vm.stopPrank();
+
+        uint256 initialTreasuryBalance = luckyBuy.treasuryBalance();
+        uint256 initialCommitBalance = luckyBuy.commitBalance();
+        uint256 initialProtocolBalance = luckyBuy.protocolBalance();
+
+        vm.deal(address(this), amount);
+
+        uint256 initialBalance = address(this).balance;
+
+        luckyBuy.commit{value: amount}(
+            address(this),
+            cosigner,
+            seed,
+            orderHash,
+            reward
+        );
+
+        assertEq(address(this).balance, initialBalance - amount);
+
+        vm.warp(block.timestamp + 2 days);
+
+        vm.prank(cosigner);
+        luckyBuy.expire(0);
+
+        assertEq(cosigner.balance, initialBalance);
+        assertEq(luckyBuy.treasuryBalance(), initialTreasuryBalance);
+        assertEq(luckyBuy.commitBalance(), initialCommitBalance);
+        assertEq(luckyBuy.protocolBalance(), initialProtocolBalance);
+    }
+
     function testExpireCommitNotOwner() public {
         vm.startPrank(admin);
         luckyBuy.setCommitExpireTime(1 days);


### PR DESCRIPTION
Gives cosigner the ability to expire a commit. 

Expired funds will go to `msg.sender`, in this instance, the cosigner. This is intended for the edge case of some user who has set a receiver that can not receive eth, tokens or some other form of footgun. 

These funds could be rescued through emergency withdrawal but that would effectively reset the contract. This gives the cosigner additional mgmt abilities so the back end can rescue funds if the user is footgunning themselves. 

This requires the cosigner key from the existing commit data. If cosigner is rotated while commits are opened that key will still be required. 