### PR TITLE
Pull LuckyBuy specific role out of MEAccessControl

### DIFF
--- a/src/LuckyBuy.sol
+++ b/src/LuckyBuy.sol
@@ -43,6 +43,9 @@ contract LuckyBuy is
     uint256 public constant ONE_PERCENT = 100;
     uint256 public constant BASE_POINTS = 10000;
 
+    bytes32 public constant FEE_RECEIVER_MANAGER_ROLE =
+        keccak256("FEE_RECEIVER_MANAGER_ROLE");
+
     mapping(address cosigner => bool active) public isCosigner;
     mapping(address receiver => uint256 counter) public luckyBuyCount;
     mapping(uint256 commitId => bool fulfilled) public isFulfilled;

--- a/src/common/MEAccessControl.sol
+++ b/src/common/MEAccessControl.sol
@@ -10,8 +10,6 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
  */
 contract MEAccessControl is AccessControl {
     bytes32 public constant OPS_ROLE = keccak256("OPS_ROLE");
-    bytes32 public constant FEE_RECEIVER_MANAGER_ROLE =
-        keccak256("FEE_RECEIVER_MANAGER_ROLE");
 
     error InvalidOwner();
 


### PR DESCRIPTION
`FEE_RECEIVER_MANAGER_ROLE` is a role specific to LuckyBuy unlike `DEFAULT_ADMIN_ROLE` and `OPS_ROLE`. 

Let's declare `FEE_RECEIVER_MANAGER_ROLE` in `LuckyBuy` making `MEAccessControl` more abstract for consumption in future top level contracts.