### PR TITLE
Disperse protocol fees on fulfillmnet

### DIFF
--- a/src/LuckyBuy.sol
+++ b/src/LuckyBuy.sol
@@ -294,6 +294,7 @@ contract LuckyBuy is
         uint256 tokenId_,
         bytes calldata signature_
     ) public payable whenNotPaused {
+        uint256 protocolFeesPaid = feesPaid[commitId_];
         _fulfill(
             commitId_,
             marketplace_,
@@ -303,6 +304,7 @@ contract LuckyBuy is
             tokenId_,
             signature_
         );
+        _sendProtocolFees(commitId_, protocolFeesPaid);
     }
 
     /// @notice Fulfills a commit with the result of the random number generation
@@ -365,6 +367,9 @@ contract LuckyBuy is
             // Subtract the split amount from the treasury balance
             treasuryBalance -= splitAmount;
         }
+
+        uint256 remainingProtocolFees = protocolFeesPaid - splitAmount;
+        _sendProtocolFees(commitId_, remainingProtocolFees);
 
         emit FeeSplit(
             commitId_,
@@ -995,5 +1000,26 @@ contract LuckyBuy is
         address oldFeeReceiver = feeReceiver;
         feeReceiver = payable(feeReceiver_);
         emit FeeReceiverUpdated(oldFeeReceiver, feeReceiver_);
+    }
+
+    /// @notice Forwards protocol fees held in treasury to the fee receiver
+    /// @param commitId_ The ID of the commit whose fees are being sent
+    /// @param amount_ The amount of fees to send
+    /// @dev If transfer fails, emits FeeTransferFailure and leaves funds in treasury
+    function _sendProtocolFees(uint256 commitId_, uint256 amount_) internal {
+        if (amount_ == 0) return;
+        if (feeReceiver == address(0)) return;
+
+        (bool success, ) = feeReceiver.call{value: amount_}("");
+        if (success) {
+            treasuryBalance -= amount_;
+        } else {
+            emit FeeTransferFailure(
+                commitId_,
+                feeReceiver,
+                amount_,
+                hash(luckyBuys[commitId_])
+            );
+        }
     }
 }

--- a/test/LuckyBuy.t.sol
+++ b/test/LuckyBuy.t.sol
@@ -1457,6 +1457,7 @@ contract TestLuckyBuyCommit is Test {
         uint256 _collectionCreatorBalance = collectionCreator.balance;
         uint256 _treasuryBalance = luckyBuy.treasuryBalance();
         uint256 _protocolBalance = luckyBuy.protocolBalance();
+        uint256 _feeReceiverBalance = address(this).balance;
         luckyBuy.fulfillWithFeeSplit(
             commitId,
             address(0), // marketplace
@@ -1470,22 +1471,24 @@ contract TestLuckyBuyCommit is Test {
         );
         vm.stopPrank();
 
+        uint256 splitAmount = (protocolFee * creatorFeeSplitPercentage) /
+            luckyBuy.BASE_POINTS();
+
         assertEq(
             collectionCreator.balance,
-            _collectionCreatorBalance +
-                (creatorFeeSplitPercentage * protocolFee) /
-                10000
+            _collectionCreatorBalance + splitAmount
         );
 
         assertEq(luckyBuy.protocolBalance(), _protocolBalance - protocolFee);
         assertEq(
             luckyBuy.treasuryBalance(),
-            _treasuryBalance +
-                commitAmount +
-                (creatorFeeSplitPercentage * protocolFee) /
-                10000
+            _treasuryBalance + commitAmount
         );
         assertEq(luckyBuy.commitBalance(), 0);
+        assertEq(
+            address(this).balance,
+            _feeReceiverBalance + (protocolFee - splitAmount)
+        );
     }
 
     function testFeeSplitInvalidPercentage() public {

--- a/test/LuckyBuyInitializable.t.sol
+++ b/test/LuckyBuyInitializable.t.sol
@@ -1480,13 +1480,13 @@ contract TestLuckyBuyCommit is Test {
 
         assertEq(luckyBuy.protocolBalance(), protocolFee);
 
-        uint256 treasuryBalance = luckyBuy.treasuryBalance();
         // Fulfill the commit
         vm.startPrank(user);
 
         uint256 _collectionCreatorBalance = collectionCreator.balance;
         uint256 _treasuryBalance = luckyBuy.treasuryBalance();
         uint256 _protocolBalance = luckyBuy.protocolBalance();
+        uint256 _feeReceiverBalance = address(this).balance;
         luckyBuy.fulfillWithFeeSplit(
             commitId,
             address(0), // marketplace
@@ -1500,22 +1500,24 @@ contract TestLuckyBuyCommit is Test {
         );
         vm.stopPrank();
 
+        uint256 splitAmount = (protocolFee * creatorFeeSplitPercentage) /
+            luckyBuy.BASE_POINTS();
+
         assertEq(
             collectionCreator.balance,
-            _collectionCreatorBalance +
-                (creatorFeeSplitPercentage * protocolFee) /
-                10000
+            _collectionCreatorBalance + splitAmount
         );
 
         assertEq(luckyBuy.protocolBalance(), _protocolBalance - protocolFee);
         assertEq(
             luckyBuy.treasuryBalance(),
-            _treasuryBalance +
-                commitAmount +
-                (creatorFeeSplitPercentage * protocolFee) /
-                10000
+            _treasuryBalance + commitAmount
         );
         assertEq(luckyBuy.commitBalance(), 0);
+        assertEq(
+            address(this).balance,
+            _feeReceiverBalance + (protocolFee - splitAmount)
+        );
     }
 
     function testFeeSplitInvalidPercentage() public {


### PR DESCRIPTION
This PR updates the fee dispersal to be immediate on fulfillment instead of keeping it in the contract along with operating balance putting a clear separation between revenue from fees generated and  operating balance