### PR TITLE
chore: balance handling updates

### DIFF
--- a/src/LuckyBuy.sol
+++ b/src/LuckyBuy.sol
@@ -410,6 +410,9 @@ contract LuckyBuy is
         treasuryBalance += protocolFeesPaid;
         protocolBalance -= protocolFeesPaid;
 
+        // Check if we have enough balance after collecting all funds
+        if (orderAmount_ > treasuryBalance) revert InsufficientBalance();
+
         // calculate the odds in base points
         uint256 odds = _calculateOdds(commitData.amount, commitData.reward);
         uint256 rng = PRNG.rng(signature_);
@@ -936,7 +939,6 @@ contract LuckyBuy is
         uint256 tokenId_,
         bytes calldata signature_
     ) internal view returns (CommitData memory, bytes32) {
-        if (orderAmount_ > treasuryBalance) revert InsufficientBalance();
         if (commitId_ >= luckyBuys.length) revert InvalidCommitId();
         if (isFulfilled[commitId_]) revert AlreadyFulfilled();
         if (isExpired[commitId_]) revert CommitIsExpired();

--- a/src/LuckyBuy.sol
+++ b/src/LuckyBuy.sol
@@ -215,7 +215,12 @@ contract LuckyBuy is
         _validateCommit(receiver_, cosigner_, reward_, commitAmount);
 
         // We collect the flat fee regardless of the amount. It is not returned to the user, ever.
-        treasuryBalance += flatFee;
+        if (flatFee > 0 && feeReceiver != address(0)) {
+            (bool success, ) = feeReceiver.call{value: flatFee}("");
+            if (!success) revert TransferFailed();
+        } else {
+            treasuryBalance += flatFee;
+        }
 
         // The fee is the amount without the flat fee minus the amount without the protocol fee
         uint256 protocolFee = amountWithoutFlatFee - commitAmount;

--- a/src/LuckyBuyInitializable.sol
+++ b/src/LuckyBuyInitializable.sol
@@ -438,6 +438,9 @@ contract LuckyBuyInitializable is
         treasuryBalance += protocolFeesPaid;
         protocolBalance -= protocolFeesPaid;
 
+        // Check if we have enough balance after collecting all funds
+        if (orderAmount_ > treasuryBalance) revert InsufficientBalance();
+
         // calculate the odds in base points
         uint256 odds = _calculateOdds(commitData.amount, commitData.reward);
         uint256 rng = PRNG.rng(signature_);
@@ -963,7 +966,6 @@ contract LuckyBuyInitializable is
         uint256 tokenId_,
         bytes calldata signature_
     ) internal view returns (CommitData memory, bytes32) {
-        if (orderAmount_ > treasuryBalance) revert InsufficientBalance();
         if (commitId_ >= luckyBuys.length) revert InvalidCommitId();
         if (isFulfilled[commitId_]) revert AlreadyFulfilled();
         if (isExpired[commitId_]) revert CommitIsExpired();

--- a/src/LuckyBuyInitializable.sol
+++ b/src/LuckyBuyInitializable.sol
@@ -242,7 +242,12 @@ contract LuckyBuyInitializable is
         _validateCommit(receiver_, cosigner_, reward_, commitAmount);
 
         // We collect the flat fee regardless of the amount. It is not returned to the user, ever.
-        treasuryBalance += flatFee;
+        if (flatFee > 0 && feeReceiver != address(0)) {
+            (bool success, ) = feeReceiver.call{value: flatFee}("");
+            if (!success) revert TransferFailed();
+        } else {
+            treasuryBalance += flatFee;
+        }
 
         // The fee is the amount without the flat fee minus the amount without the protocol fee
         uint256 protocolFee = amountWithoutFlatFee - commitAmount;

--- a/test/LuckyBuy.t.sol
+++ b/test/LuckyBuy.t.sol
@@ -2030,5 +2030,62 @@ contract TestLuckyBuyCommit is Test {
         vm.stopPrank();
     }
 
+    function testFulfillWithTopOff() public {
+        bytes32 correctOrderHash = luckyBuy.hashOrder(
+            marketplace,
+            reward,
+            orderData,
+            orderToken,
+            orderTokenId
+        );
+        
+        vm.startPrank(user);
+        vm.deal(user, amount);
+        uint256 commitId = luckyBuy.commit{value: amount}(
+            receiver,
+            cosigner,
+            seed,
+            correctOrderHash,
+            reward
+        );
+        vm.stopPrank();
+
+        // Empty the treasury so there's not enough to cover the reward
+        vm.startPrank(admin);
+        uint256 treasuryBalance = luckyBuy.treasuryBalance();
+        if (treasuryBalance > 0) {
+            luckyBuy.withdraw(treasuryBalance);
+        }
+        vm.stopPrank();
+
+        bytes memory signature = signCommit(
+            commitId,
+            receiver,
+            seed,
+            0,
+            correctOrderHash,
+            amount,
+            reward
+        );
+
+        uint256 topOffAmount = reward - amount;
+        vm.deal(user, topOffAmount);
+        vm.startPrank(user);
+        
+        luckyBuy.fulfill{value: topOffAmount}(
+            commitId,
+            marketplace,
+            orderData,
+            reward,
+            orderToken,
+            orderTokenId,
+            signature
+        );
+        
+        vm.stopPrank();
+
+        assertTrue(luckyBuy.isFulfilled(commitId));
+    }
+
     receive() external payable {}
 }

--- a/test/LuckyBuy.t.sol
+++ b/test/LuckyBuy.t.sol
@@ -273,8 +273,8 @@ contract TestLuckyBuyCommit is Test {
         assertEq(storedAmount, amount, "Amount should match");
         assertEq(storedReward, reward, "Reward should match");
 
-        // Flat Fee goes straight to treasury, lb has not been funded yet
-        assertEq(luckyBuy.treasuryBalance(), flatFeeAmount);
+        // Flat Fee goes straight to fee receiver
+        assertEq(admin.balance, 100 ether + flatFeeAmount);
         vm.stopPrank();
     }
 

--- a/test/LuckyBuyInitializable.t.sol
+++ b/test/LuckyBuyInitializable.t.sol
@@ -309,8 +309,8 @@ contract TestLuckyBuyCommit is Test {
         assertEq(storedAmount, amount, "Amount should match");
         assertEq(storedReward, reward, "Reward should match");
 
-        // Flat Fee goes straight to treasury, lb has not been funded yet
-        assertEq(luckyBuy.treasuryBalance(), flatFeeAmount);
+        // Flat Fee goes straight to fee receiver
+        assertEq(admin.balance, 100 ether + flatFeeAmount);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
Two main changes 

1. To keep accounting more clean we move the flat fee to the fee receiver as well like we do for the protocol fee (if one is set) if not the value is kept in the contract

2. Before we had to send funds even if the lucky buy spin was a loss. Moving the fulfillment balance check further down allows us to top off conditionally on win.

* Updated tests for change 1 and added tests for change 2
