### PR TITLE
[Packs] Cosigner only fulfill

### DIFF
--- a/src/common/Errors.sol
+++ b/src/common/Errors.sol
@@ -9,4 +9,5 @@ library Errors {
     error InvalidAmount();
     error InsufficientBalance();
     error ArrayLengthMismatch();
+    error Unauthorized();
 }


### PR DESCRIPTION
There aren't any unsigned parameters like `fees` in Packs as there is in LuckyBuy, but I feel it's sensible to scope the Packs `fulfill` to the commit's `cosigner` too for consistency.

Ref: #80 