### PR TITLE
[Packs] fix max reward multi value + add initial value

### DIFF
--- a/src/Packs.sol
+++ b/src/Packs.sol
@@ -148,7 +148,7 @@ contract Packs is
         maxPackPrice = 0.25 ether;
 
         minPackRewardMultiplier = 5000;
-        maxPackRewardMultiplier = 30000;
+        maxPackRewardMultiplier = 300000;
 
         // Initialize expiries
         commitCancellableTime = 1 days;

--- a/src/PacksInitializable.sol
+++ b/src/PacksInitializable.sol
@@ -44,6 +44,9 @@ contract PacksInitializable is Packs, UUPSUpgradeable {
         minPackPrice = 0.01 ether;
         maxPackPrice = 0.25 ether;
 
+        minPackRewardMultiplier = 5000;
+        maxPackRewardMultiplier = 300000;
+
         // Initialize expiries
         commitCancellableTime = 1 days;
         nftFulfillmentExpiryTime = 10 minutes;

--- a/test/Packs.t.sol
+++ b/test/Packs.t.sol
@@ -181,7 +181,7 @@ contract TestPacks is Test {
         assertEq(packs.minPackPrice(), 0.01 ether);
         assertEq(packs.maxPackPrice(), 0.25 ether);
         assertEq(packs.minPackRewardMultiplier(), 5000);
-        assertEq(packs.maxPackRewardMultiplier(), 30000);
+        assertEq(packs.maxPackRewardMultiplier(), 300000);
     }
 
     function testCommitSuccess() public {


### PR DESCRIPTION
- Increase max reward value multiplier to 30x
- Set default values in `PacksInitializable`